### PR TITLE
Add links for Chart2Music

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ A non-exhaustive and in-progress list of people and resources in Accessibility a
 * [VCC Color Utilities](https://github.com/visa/visa-chart-components/blob/master/packages/utils/README.md#colors)
 * [VCC Texture Utility](https://github.com/visa/visa-chart-components/blob/master/packages/utils/README.md#textures)
 
+### Chart2Music
+* A visual-agnostic tool to add keyboard navigation and sonification to charts. While not a framework, it can be used to augment accessibility for other dataviz frameworks
+* [Chart2Music documentation site](https://chart2music.com/docs/)
+* [Chart2Music CodePen examples](https://codepen.io/collection/BNedqm)
+
 ---
 
 ##  People and Articles in Dataviz & Accessibility (Academia)

--- a/README.md
+++ b/README.md
@@ -182,8 +182,10 @@ A non-exhaustive and in-progress list of people and resources in Accessibility a
 * [VCC Color Utilities](https://github.com/visa/visa-chart-components/blob/master/packages/utils/README.md#colors)
 * [VCC Texture Utility](https://github.com/visa/visa-chart-components/blob/master/packages/utils/README.md#textures)
 
+## Javascript Tools that can Assist with Visualization Accessibility
+
 ### Chart2Music
-* A visual-agnostic tool to add keyboard navigation and sonification to charts. While not a framework, it can be used to augment accessibility for other dataviz frameworks
+* A visual-agnostic tool to add keyboard navigation and sonification to charts.
 * [Chart2Music documentation site](https://chart2music.com/docs/)
 * [Chart2Music CodePen examples](https://codepen.io/collection/BNedqm)
 


### PR DESCRIPTION
Hi! I am on the team that built Chart2Music, which can improve the accessibility of charts and graphs by incorporating interactive sonification. [Chart2Music](https://chart2music.com/docs/) was written specifically to improve accessibility for blind users, though it can help provide keyboard navigation for keyboard-only users.

Is it possible to add this tool to the list of resources?